### PR TITLE
Refactor blog content

### DIFF
--- a/dbt_project/models/blog/intermediate/imp_click.sql
+++ b/dbt_project/models/blog/intermediate/imp_click.sql
@@ -1,10 +1,11 @@
 {{
     config(
-        description="3月以内のサイトごとのimp click.",
+        description="当月含む三ヶ月以内のサイトごとのpv",
     )
 }}
 select
     data_date,
+    
     regexp_replace(url, '/$', '') as url,
     sum(impressions) as impressions,
     sum(clicks) as clicks

--- a/dbt_project/models/blog/intermediate/pv.sql
+++ b/dbt_project/models/blog/intermediate/pv.sql
@@ -1,6 +1,6 @@
 {{
     config(
-        description="3月以内のサイトごとのpv",
+        description="当月含む三ヶ月以内のサイトごとのpv",
     )
 }}
 with
@@ -16,7 +16,7 @@ with
             and _table_suffix
             between format_date(
                 '%Y%m%d',
-                date_add(current_date("Asia/Tokyo"), interval -3 month)
+                date_add(current_date("Asia/Tokyo"), interval -2 month)
             ) and format_date(
                 '%Y%m%d', date_add(current_date("Asia/Tokyo"), interval -1 day)
             )

--- a/dbt_project/models/blog/marts/blog/metrics.sql
+++ b/dbt_project/models/blog/marts/blog/metrics.sql
@@ -1,8 +1,0 @@
-{{
-    config(
-        description="サイトごとの日付別pv imp click.",
-    )
-}}
-select p.*, c.* except (data_date, url)
-from {{ ref("pv") }} as p
-left join {{ ref("imp_click") }} as c on p.d = c.data_date and p.page_location = c.url

--- a/dbt_project/reports/pages/index.md
+++ b/dbt_project/reports/pages/index.md
@@ -37,7 +37,7 @@ queries:
   />
 
   <BarChart 
-      data={tag_count.where(`count >= 3`)}
+      data={tag_count}
       x=created_at
       y=count
       series=tag
@@ -98,7 +98,7 @@ queries:
 />
 
 <LineChart 
-    data={rank_month.where(`pv_rank <= 10`)}
+    data={rank_month}
     x=month
     y=pv_rank
     yMin=1
@@ -112,7 +112,7 @@ queries:
     echartsOptions={{ yAxis: {inverse: true }, tooltip: {show: false}}}
 >
     <ReferencePoint
-      data={rank_month.where(`pv_rank <= 10`)}
+      data={rank_month}
       x=month
       y=pv_rank
       label=page_title_offset labelPosition=right

--- a/dbt_project/reports/queries/blog/tag_count.sql
+++ b/dbt_project/reports/queries/blog/tag_count.sql
@@ -1,1 +1,2 @@
 select * from free.tag_count
+where count >= 3

--- a/dlt_project/github/blog_content.py
+++ b/dlt_project/github/blog_content.py
@@ -132,9 +132,9 @@ class GitHubMarkdownFetcher:
 
 @dlt.resource(
     name="blog_content",
+    primary_key="path",
     merge_key="last_modified",
     write_disposition="merge"
-    # write_disposition="replace"
 )
 def get_resources(fetcher: GitHubMarkdownFetcher):
     # print(f"fmarkdown sile, {next(fetcher.get_all_files())}")


### PR DESCRIPTION
クエリの置き場所と、実行場所の調整

martの前段テーブルを中間テーブルとして

ダッシュボードでグラフ表示がやや遅れるものについてquery functionsの実行場所をqueriesないで行ってみる