### PR TITLE
create volume for container

### DIFF
--- a/dbt_project/reports/docker-compose.yml
+++ b/dbt_project/reports/docker-compose.yml
@@ -9,8 +9,12 @@ services:
       - "3000:3000"
     volumes:
       - .:/app
-      #- host-node-modules:/app/node_modules
-      #- host-evidence:/app/.evidence
+      - host_node_modules:/app/node_modules
+      - host_evidence:/app/.evidence
     env_file:
       - .env
     command: sh -c "npm run sources && npm run dev"
+
+volumes:
+  host_node_modules:
+  host_evidence:


### PR DESCRIPTION
コンテナで起動させた際に生成したファイルが共有されていると
localで起動させたときにファイルの権限周りでエラーが起きるのでvolumeを指定してhost側のプロジェクトに同期しないようにする